### PR TITLE
zrobot config

### DIFF
--- a/templates/zrobot_config/zrobot_config.py
+++ b/templates/zrobot_config/zrobot_config.py
@@ -52,6 +52,7 @@ class ZrobotConfig(TemplateBase):
             j.core.state.configSetInDict("myconfig", "backend_addr", "{}:{}".format(hostname, port))
             j.core.state.configSetInDict("myconfig", "adminsecret", admin_password)
             j.core.state.configSetInDict("myconfig", "secrets", "")
+            j.core.state.configSetInDict("myconfig", "namespace", namespace)
             self._kill_robot()
 
     def delete(self):
@@ -61,4 +62,6 @@ class ZrobotConfig(TemplateBase):
         if j.sal.fs.exists(CONFIG_PATH):
             j.sal.fs.remove(CONFIG_PATH)
 
+        # Should reset backend to file
+        j.core.state.configSetInDict("myconfig", "backend", "file")
         self._kill_robot()

--- a/templates/zrobot_config/zrobot_config.py
+++ b/templates/zrobot_config/zrobot_config.py
@@ -29,8 +29,6 @@ class ZrobotConfig(TemplateBase):
         install writes the config, then send a signal to the robot to stop itself
         in production 0-os will detect that the robot stops and will restart it
         """
-        if not j.sal.fs.exists(CONFIG_PATH):
-            j.sal.fs.touch(CONFIG_PATH)
         j.data.serializer.yaml.dump(
             CONFIG_PATH,
             {'zdb_url': self.data['dataRepo']}
@@ -46,14 +44,15 @@ class ZrobotConfig(TemplateBase):
         if j.core.state.configGetFromDict("myconfig", "backend") == "db":
             j.tools.configmanager.set_namespace(namespace)
             # Robot should be running using a sandbox
-            j.tools.configmanager.configure_keys_from_paths(config.config_repo.key)
+            j.tools.configmanager.configure_keys_from_paths(config.config_repo.key, config.config_repo.key + ".pub")
         else:
             j.core.state.configSetInDict("myconfig", "backend", "db")
             j.core.state.configSetInDict("myconfig", "backend_addr", "{}:{}".format(hostname, port))
             j.core.state.configSetInDict("myconfig", "adminsecret", admin_password)
             j.core.state.configSetInDict("myconfig", "secrets", "")
             j.core.state.configSetInDict("myconfig", "namespace", namespace)
-            self._kill_robot()
+
+        self._kill_robot()
 
     def delete(self):
         """

--- a/templates/zrobot_config/zrobot_config.py
+++ b/templates/zrobot_config/zrobot_config.py
@@ -5,6 +5,7 @@ from jumpscale import j
 
 from zerorobot.template.base import TemplateBase
 from zerorobot.config.data_repo import _parse_zdb
+from zerorobot import config
 
 CONFIG_PATH = '/opt/var/data/zrobot/zrobot_data/data_repo.yaml'
 
@@ -28,19 +29,30 @@ class ZrobotConfig(TemplateBase):
         install writes the config, then send a signal to the robot to stop itself
         in production 0-os will detect that the robot stops and will restart it
         """
-
+        if not j.sal.fs.exists(CONFIG_PATH):
+            j.sal.fs.touch(CONFIG_PATH)
         j.data.serializer.yaml.dump(
             CONFIG_PATH,
             {'zdb_url': self.data['dataRepo']}
         )
-        if j.core.state.configGetFromDict("myconfig", "backend") != "db":
-            (admin_password, hostname, port, namespace) = _parse_zdb(self.data['dataRepo'])
+        admin_password, hostname, port, namespace = _parse_zdb(self.data['dataRepo'])
+        if not port:
+            port = 9900
+        if not namespace:
+            namespace = "default"
+        if not admin_password:
+            admin_password = ""
 
+        if j.core.state.configGetFromDict("myconfig", "backend") == "db":
+            j.tools.configmanager.set_namespace(namespace)
+            # Robot should be running using a sandbox
+            j.tools.configmanager.configure_keys_from_sandbox(config.config_repo.path)
+        else:
+            j.core.state.configSetInDict("myconfig", "backend", "db")
             j.core.state.configSetInDict("myconfig", "backend_addr", "{}:{}".format(hostname, port))
             j.core.state.configSetInDict("myconfig", "adminsecret", admin_password)
-            secrets = j.core.state.configGetSetInDict("myconfig", "secrets", "")
-
-        self._kill_robot()
+            j.core.state.configSetInDict("myconfig", "secrets", "")
+            self._kill_robot()
 
     def delete(self):
         """

--- a/templates/zrobot_config/zrobot_config.py
+++ b/templates/zrobot_config/zrobot_config.py
@@ -46,7 +46,7 @@ class ZrobotConfig(TemplateBase):
         if j.core.state.configGetFromDict("myconfig", "backend") == "db":
             j.tools.configmanager.set_namespace(namespace)
             # Robot should be running using a sandbox
-            j.tools.configmanager.configure_keys_from_sandbox(config.config_repo.path)
+            j.tools.configmanager.configure_keys_from_paths(config.config_repo.key)
         else:
             j.core.state.configSetInDict("myconfig", "backend", "db")
             j.core.state.configSetInDict("myconfig", "backend_addr", "{}:{}".format(hostname, port))

--- a/templates/zrobot_config/zrobot_config.py
+++ b/templates/zrobot_config/zrobot_config.py
@@ -33,6 +33,13 @@ class ZrobotConfig(TemplateBase):
             CONFIG_PATH,
             {'zdb_url': self.data['dataRepo']}
         )
+        if j.core.state.configGetFromDict("myconfig", "backend") != "db":
+            (admin_password, hostname, port, namespace) = _parse_zdb(self.data['dataRepo'])
+
+            j.core.state.configSetInDict("myconfig", "backend_addr", "{}:{}".format(hostname, port))
+            j.core.state.configSetInDict("myconfig", "adminsecret", admin_password)
+            secrets = j.core.state.configGetSetInDict("myconfig", "secrets", "")
+
         self._kill_robot()
 
     def delete(self):


### PR DESCRIPTION
Implements install, delete methods

Basically, sets the backend to db and configure that in jumpscale.toml file and the *namespace* too
for delete it resets the backend of config manager to file