### PR TITLE
Refactor namespace selfhealing

### DIFF
--- a/templates/namespace/namespace.py
+++ b/templates/namespace/namespace.py
@@ -38,20 +38,20 @@ class Namespace(TemplateBase):
         except StateCheckError:
             return
 
-        def _reinstall():
+        if not self.data['zerodb']:
+            # Reinstall on a different zerodb
             self.state.delete('status', 'running')
             self.install()
-
-        if not self.data['zerodb']:
-            _reinstall()
 
         try:
             self._zerodb.state.check('status', 'running', 'ok')
             self.state.set('status', 'running', 'ok')
         except StateCheckError:
             self.logger.info('Zerodb is not reachable anymore, installing namespace on a different zerodb')
+            # Reinstall on a different zerodb
             self.data['zerodb'] = ''
-            _reinstall()
+            self.state.delete('status', 'running')
+            self.install()
 
     @property
     def _zerodb(self):

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -128,8 +128,8 @@ class Node(TemplateBase):
         self.state.set('actions', 'install', 'ok')
 
     def reboot(self):
-        self._stop_all_containers()
-        self._stop_all_vms()
+        # self._stop_all_containers()
+        # self._stop_all_vms()
 
         self.logger.info('Rebooting node %s' % self.name)
         self.state.set('status', 'rebooting', 'ok')
@@ -243,6 +243,8 @@ class Node(TemplateBase):
                 return False
             if info['type'] not in disktypes:
                 return False
+            if not info['running']:
+                return False
             return True
 
         zdbinfos = list(filter(usable_zdb, self._list_zdbs_info()))
@@ -252,7 +254,7 @@ class Node(TemplateBase):
 
         # sort result by free size, first item of the list is the the one with bigger free size
         for zdbinfo in sorted(zdbinfos, key=lambda r: r['free'], reverse=True):
-            zdb = self.api.services.get(template_name=ZDB_TEMPLATE_UID, name=zdbinfo['service_name'])
+            zdb = self.api.services.get(template_uid=ZDB_TEMPLATE_UID, name=zdbinfo['service_name'])
             namespaces = [ns['name'] for ns in zdb.schedule_action('namespace_list').wait(die=True).result]
             if namespace_name not in namespaces:
                 zdb.schedule_action('namespace_create', namespace).wait(die=True)

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -64,15 +64,6 @@ class Node(TemplateBase):
         except:
             self.state.delete('disks', 'mounted')
 
-        try:
-            # check if the node was rebooting and start containers and vms
-            self.state.check('status', 'rebooting', 'ok')
-            # self._start_all_containers()
-            # self._start_all_vms()
-            self.state.delete('status', 'rebooting')
-        except StateCheckError:
-            pass
-
     def _network_monitor(self):
         self.state.check('actions', 'install', 'ok')
 
@@ -128,11 +119,7 @@ class Node(TemplateBase):
         self.state.set('actions', 'install', 'ok')
 
     def reboot(self):
-        # self._stop_all_containers()
-        # self._stop_all_vms()
-
         self.logger.info('Rebooting node %s' % self.name)
-        self.state.set('status', 'rebooting', 'ok')
         self._node_sal.reboot()
 
     def zdb_path(self, disktype, size, name):

--- a/templates/vm/vm.py
+++ b/templates/vm/vm.py
@@ -55,7 +55,6 @@ class Vm(TemplateBase):
         except StateCheckError:
             return
 
-        self.state.set('status', 'running', 'ok')
         vm_sal = self._vm_sal
 
         if not vm_sal.is_running():
@@ -72,6 +71,10 @@ class Vm(TemplateBase):
 
             if not vm_sal.is_running():
                 self.state.delete('status', 'running')
+            else:
+                self.state.set('status', 'running', 'ok')
+        else:
+            self.state.set('status', 'running', 'ok')
 
         # handle reboot
         try:


### PR DESCRIPTION
If a zerodb fails to start, reinstall namespaces on this zerodb on other zerodbs. 
Also, filter out zerodbs that are not running while determining which zdb to create a namespace on.
