### PR TITLE
BLOCKED: Refactor namespace/zdb flow

### DIFF
--- a/templates/namespace/namespace.py
+++ b/templates/namespace/namespace.py
@@ -125,21 +125,20 @@ class Namespace(TemplateBase):
         return self._zerodb.schedule_action('namespace_private_url', args={'name': self.data['nsName']}).wait(die=True).result
 
     def uninstall(self):
-        if not self.data['zerodb']:
-            self.state.delete('actions', 'install')
-            return
-        try:
-            if self.data['diskType'] == 'ssd':
-                zdb = self._zerodb
-                zdb.schedule_action('namespace_delete', args={'name': self.data['nsName']}).wait(die=True)
-                zdb.schedule_action('uninstall').wait(die=True)
-                zdb.delete()
-            if self.data['diskType'] == 'hdd':
-                self._zerodb.schedule_action('namespace_delete', args={'name': self.data['nsName']}).wait(die=True)
-        except ServiceNotFoundError:
-            pass
+        if self.data['zerodb']:
+            try:
+                if self.data['diskType'] == 'ssd':
+                    zdb = self._zerodb
+                    zdb.schedule_action('namespace_delete', args={'name': self.data['nsName']}).wait(die=True)
+                    zdb.schedule_action('uninstall').wait(die=True)
+                    zdb.delete()
+                if self.data['diskType'] == 'hdd':
+                    self._zerodb.schedule_action('namespace_delete', args={'name': self.data['nsName']}).wait(die=True)
+            except ServiceNotFoundError:
+                pass
+            self.data['zerodb'] = ''
 
-        self.data['zerodb'] = ''
+        self.state.delete('status', 'running')
         self.state.delete('actions', 'install')
 
     def connection_info(self):

--- a/templates/namespace/namespace.py
+++ b/templates/namespace/namespace.py
@@ -128,7 +128,6 @@ class Namespace(TemplateBase):
         if not self.data['zerodb']:
             self.state.delete('actions', 'install')
             return
-        import pdb; pdb.set_trace()
         try:
             if self.data['diskType'] == 'ssd':
                 zdb = self._zerodb

--- a/templates/namespace/schema.capnp
+++ b/templates/namespace/schema.capnp
@@ -2,11 +2,11 @@
 
 
 struct Schema {
-    size @0: Int32; # size of the namespace
+    size @0 :Int32; # size of the namespace
     diskType @1 :DiskType; # type of disk to use for this namespace
     mode @2 :Mode; # zero-db mode
     public @3 :Bool; # see https://github.com/rivine/0-db#nsset for detail about public mode
-    password @4: Text; # password of the namespace. if empty it will be generated automatically
+    password @4 :Text; # password of the namespace. if empty it will be generated automatically
     zerodb @5 :Text; # instance name of the zerodb where the namespace is deployed. User don't have to fill this attribute
     nsName @6 :Text;
 

--- a/templates/node/node.py
+++ b/templates/node/node.py
@@ -297,7 +297,7 @@ class Node(TemplateBase):
         """
         def usable_zdb(zdb):
             try:
-                zdb.state.check('status', 'running', 'true')
+                zdb.state.check('status', 'running', 'ok')
                 return True
             except StateCheckError:
                 return False

--- a/templates/vdisk/schema.capnp
+++ b/templates/vdisk/schema.capnp
@@ -1,14 +1,14 @@
-@0xcd4c6fb7346ea294; 
+@0xcd4c6fb7346ea294;
 
 
 struct Schema {
-    size @0: Int32; # size of the vdisk and namespace
+    size @0 :Int32; # size of the vdisk and namespace
     diskType @1 :DiskType; # type of disk to use for the namespace
     mountPoint @2 :Text;
     filesystem @3 :Text;
-    zerodb @4 :Text; # instance name of the zerodb where the namespace is deployed. User doesn't have to fill this attribute.
-    nsName @5: Text; # name of the namespace to be created on zerodb. User doesn't have to fill this attribute.
-    label @6: Text; # label to be used for the disk on any vm
+    namespace @4 :Text; # instance name of the zerodb where the namespace is deployed. User doesn't have to fill this attribute.
+    nsName @5 :Text; # name of the namespace to be created on zerodb. User doesn't have to fill this attribute.
+    label @6 :Text; # label to be used for the disk on any vm
 
     enum DiskType{
         hdd @0;

--- a/templates/vdisk/vdisk.py
+++ b/templates/vdisk/vdisk.py
@@ -30,7 +30,6 @@ class Vdisk(TemplateBase):
             if not self.data.get(param):
                 raise ValueError("parameter '%s' not valid: %s" % (param, str(self.data[param])))
 
-        self.data['password'] = self.data['password'] if self.data['password'] else j.data.idgenerator.generateXCharID(32)
         self.data['nsName'] = self.data['nsName'] if self.data['nsName'] else j.data.idgenerator.generateGUID()
 
     @property
@@ -52,7 +51,7 @@ class Vdisk(TemplateBase):
         self.state.check('actions', 'install', 'ok')
 
         try:
-            self._zerodb.state.check('status', 'running', 'ok')
+            self._namespace.state.check('status', 'running', 'ok')
             self.state.set('status', 'running', 'ok')
         except StateCheckError:
             data = {
@@ -81,7 +80,6 @@ class Vdisk(TemplateBase):
         kwargs = {
             'diskType': self.data['diskType'],
             'mode': 'user',
-            'password': self.data['password'],
             'public': False,
             'size': int(self.data['size']),
             'nsName': self.data['nsName'],

--- a/templates/zerodb/schema.capnp
+++ b/templates/zerodb/schema.capnp
@@ -9,7 +9,7 @@ struct Schema {
     namespaces @4: List(Namespace); # a list of namespaces deployed on this zerodb
     nics @5 :List(Nic); # Configuration of the attached nics to the zerodb container
     ztIdentity @6: Text; # ztidentity of the container running 0-db
-    size @7: Int32; # disk size of the 0-db. Only applicable for
+    size @7: Int32; # disk size of the 0-db. Only applicable for ssd.
     diskType @8 :DiskType; # type of disk to use for this zerodb
     nodePort @9 :Int32; # public listening port
 

--- a/templates/zerodb/zerodb.py
+++ b/templates/zerodb/zerodb.py
@@ -282,4 +282,5 @@ class Zerodb(TemplateBase):
         self.logger.info('Uninstalling zerodb %s' % self.name)
         self._zerodb_sal.destroy()
         self.state.delete('actions', 'install')
+        self.state.delete('actions', 'start')
         self.state.delete('status', 'running')

--- a/templates/zerodb/zerodb.py
+++ b/templates/zerodb/zerodb.py
@@ -27,16 +27,6 @@ class Zerodb(TemplateBase):
         if not self.data['admin']:
             self.data['admin'] = j.data.idgenerator.generateXCharID(25)
 
-        # if self.data['path']:
-        #     zdbs = self.api.services.find(template_uid=ZDB_TEMPLATE_UID)
-        #     tasks = [zdb.schedule_action('path') for zdb in zdbs if zdb.name != self.name]
-        #     paths = []
-        #     for t in tasks:
-        #         path = t.wait(timeout=30, die=True).result
-        #         paths.append(path)
-        #     if self.data['path'] in paths:
-        #             raise ValueError('Path {} is already used by another zerodb service'.format(self.data['path']))
-
     @property
     def _zerodb_sal(self):
         data = self.data.copy()

--- a/templates/zerodb/zerodb.py
+++ b/templates/zerodb/zerodb.py
@@ -280,7 +280,6 @@ class Zerodb(TemplateBase):
         uninstall zerodb server
         """
         self.logger.info('Uninstalling zerodb %s' % self.name)
-        import pdb; pdb.set_trace()
         self._zerodb_sal.destroy()
         self.state.delete('actions', 'install')
         self.state.delete('status', 'running')

--- a/templates/zerodb/zerodb.py
+++ b/templates/zerodb/zerodb.py
@@ -27,15 +27,15 @@ class Zerodb(TemplateBase):
         if not self.data['admin']:
             self.data['admin'] = j.data.idgenerator.generateXCharID(25)
 
-        if self.data['path']:
-            zdbs = self.api.services.find(template_uid=ZDB_TEMPLATE_UID)
-            tasks = [zdb.schedule_action('path') for zdb in zdbs if zdb.name != self.name]
-            paths = []
-            for t in tasks:
-                path = t.wait(timeout=30, die=True).result
-                paths.append(path)
-            if self.data['path'] in paths:
-                    raise ValueError('Path {} is already used by another zerodb service'.format(self.data['path']))
+        # if self.data['path']:
+        #     zdbs = self.api.services.find(template_uid=ZDB_TEMPLATE_UID)
+        #     tasks = [zdb.schedule_action('path') for zdb in zdbs if zdb.name != self.name]
+        #     paths = []
+        #     for t in tasks:
+        #         path = t.wait(timeout=30, die=True).result
+        #         paths.append(path)
+        #     if self.data['path'] in paths:
+        #             raise ValueError('Path {} is already used by another zerodb service'.format(self.data['path']))
 
     @property
     def _zerodb_sal(self):
@@ -274,3 +274,13 @@ class Zerodb(TemplateBase):
     def _reserve_port(self):
         port_mgr = self.api.services.get(template_uid=PORT_MANAGER_TEMPLATE_UID, name='_port_manager')
         self.data['nodePort'] = port_mgr.schedule_action("reserve", {"service_guid": self.guid, 'n': 1}).wait(die=True).result[0]
+
+    def uninstall(self):
+        """
+        uninstall zerodb server
+        """
+        self.logger.info('Uninstalling zerodb %s' % self.name)
+        import pdb; pdb.set_trace()
+        self._zerodb_sal.destroy()
+        self.state.delete('actions', 'install')
+        self.state.delete('status', 'running')


### PR DESCRIPTION
- For ssd namespaces, create the zerodb service in the namespace template to be able to properly clean it up when you uninstall.
- Refactor vdisk to be related to a certain namespace service instead of zerodb.
- Fix zerodb creation which was failing due to some bugs introduced a while ago.

Fixes https://github.com/threefoldtech/0-templates/issues/217 and https://github.com/threefoldtech/0-templates/issues/215