### PR TITLE
S3 namespace healing

### DIFF
--- a/templates/namespace/namespace.py
+++ b/templates/namespace/namespace.py
@@ -38,20 +38,11 @@ class Namespace(TemplateBase):
         except StateCheckError:
             return
 
-        if not self.data['zerodb']:
-            # Reinstall on a different zerodb
-            self.state.delete('status', 'running')
-            self.install()
-
         try:
             self._zerodb.state.check('status', 'running', 'ok')
             self.state.set('status', 'running', 'ok')
         except StateCheckError:
-            self.logger.info('Zerodb is not reachable anymore, installing namespace on a different zerodb')
-            # Reinstall on a different zerodb
-            self.data['zerodb'] = ''
             self.state.delete('status', 'running')
-            self.install()
 
     @property
     def _zerodb(self):
@@ -61,8 +52,6 @@ class Namespace(TemplateBase):
         try:
             # no op is already installed
             self.state.check('actions', 'install', 'ok')
-            if self.data['zerodb']:
-                return
         except StateCheckError:
             pass
 
@@ -99,3 +88,4 @@ class Namespace(TemplateBase):
     def connection_info(self):
         self.state.check('actions', 'install', 'ok')
         return self._zerodb.schedule_action('connection_info').wait(die=True).result
+

--- a/templates/s3/schema.capnp
+++ b/templates/s3/schema.capnp
@@ -16,6 +16,7 @@ struct Schema {
     nsPassword @12: Text; # Namespace password
     minioBlockSize @13 :UInt32=1048576; # minio data block size in bytes
     nsName @14 :Text; # Namespace name prefix that will be used for naming all zdb reservations. Should be unique between different S3 deployments.
+    deletableNamespaces @15 :List(Namespace);
 
     enum StorageType {
      hdd @0;


### PR DESCRIPTION
- Remove selfhealing from namespace template.
- in s3 if we fail to uninstall a namespace, keep track of it until we successfully remove it