### PR TITLE
continue dm vm testcases

### DIFF
--- a/tests/config.ini
+++ b/tests/config.ini
@@ -1,6 +1,6 @@
 [zt]
-zt_client =
-zt_netwrok_id =
+zt_client = 
+zt_netwrok_id = 
 
 [robot]
 client = controller
@@ -10,6 +10,3 @@ remote_server =
 
 [vm]
 ssh =
-
-[node]
-node = 

--- a/tests/controller/templates_manager/general_temp/dm_vm.py
+++ b/tests/controller/templates_manager/general_temp/dm_vm.py
@@ -35,7 +35,7 @@ class DMVMManager:
                         'type': 'zerotier', 'id': config['zt']['zt_netwrok_id'],
                         'ztClient': zt_client.service_name},
             'image': 'ubuntu',
-            'nodeId': config['node']['nodeid'],
+            'nodeId': self._parent.node.name,
             'ports': [{'source': ssh_port, 'target': 22, 'name': 'ssh'}],
             'configs': [
                 {'path': '/root/.ssh/authorized_keys', 'content': config['vm']['ssh'],

--- a/tests/testcases/a_basics/bridge_testcases.py
+++ b/tests/testcases/a_basics/bridge_testcases.py
@@ -3,7 +3,6 @@ from nose_parameterized import parameterized
 import unittest
 import time, random
 
-@unittest.skip("https://github.com/threefoldtech/0-templates/issues/260")
 class BridgeTestCases(BaseTest):
     def setUp(self):
         super().setUp()
@@ -24,7 +23,7 @@ class BridgeTestCases(BaseTest):
         
     @parameterized.expand(['none', 'static', 'dnsmasq'])
     def test001_create_bridge(self, mode):
-        """ ZRT-ZOS-030
+        """ ZRT-ZOS-026
         *Test case for creating bridge *
 
         **Test Scenario:**
@@ -55,9 +54,9 @@ class BridgeTestCases(BaseTest):
         addrs = [addr['addr'] for addr in nic[0]['addrs']][0]
         self.assertIn(bridge.default_data['settings']['cidr'], addrs)
 
-    @unittest.skip("https://github.com/threefoldtech/0-templates/issues/260")
+    @unittest.skip("https://github.com/threefoldtech/0-templates/issues/258")
     def test002_uninstall_bridge(self):
-        """ ZRT-ZOS-031
+        """ ZRT-ZOS-027
         *Test case for uninstalling bridge *
 
         **Test Scenario:**
@@ -83,8 +82,9 @@ class BridgeTestCases(BaseTest):
         bridge_list = self.node.client.bridge.list()
         self.assertNotIn(bridge.default_data['name'], bridge_list)
 
+    @unittest.skip("https://github.com/threefoldtech/0-templates/issues/258")
     def test003_create_bridge_with_hw_addr(self):
-        """ ZRT-ZOS-032
+        """ ZRT-ZOS-028
         *Test case for creating bridge with specificed hardware address*
 
         **Test Scenario:**
@@ -114,7 +114,7 @@ class BridgeTestCases(BaseTest):
 
     @unittest.skip("https://github.com/threefoldtech/0-core/issues/87")
     def test004_create_bridge_with_invalid_data(self):
-        """ ZRT-ZOS-033
+        """ ZRT-ZOS-029
         *Test case for creating bridge with invalid data*
 
         **Test Scenario:**
@@ -157,8 +157,8 @@ class BridgeTestCases(BaseTest):
         bridge.service.delete()
 
     @unittest.skip("https://github.com/threefoldtech/0-templates/issues/258")
-    def test003_add_remove_list_nics_for_bridge(self):
-        """ ZRT-ZOS-034
+    def test005_add_remove_list_nics_for_bridge(self):
+        """ ZRT-ZOS-030
         *Test case for adding, removing and listing nics for a bridges*
 
         **Test Scenario:**
@@ -202,8 +202,8 @@ class BridgeTestCases(BaseTest):
         self.node.client.bash('ip link delete {} type dummy'.format(nic_name)).get()
     
     @parameterized.expand(["True", "False"])
-    def test005_create_bridges_with_nat_parameter(self, nat):
-        """ ZRT-ZOS-035
+    def test006_create_bridges_with_nat_parameter(self, nat):
+        """ ZRT-ZOS-031
         *Test case for creating bridge with nat paramter*
 
         **Test Scenario:**
@@ -241,7 +241,7 @@ class BridgeTestCases(BaseTest):
         self.assertEqual(response.state, 'SUCCESS', response.stderr)
 
         self.log('set network interface eth0 as default route, should succeed')
-        response = cont.client.bash('ip route add default dev eth0 via {}'.format(cidr)).get()
+        response = cont.client.bash('ip route add default dev eth0 via {}'.format(cidr[:cidr.find('/')])).get()
         self.assertEqual(response.state, 'SUCCESS', response.stderr)
 
         if nat == "True":

--- a/tests/testcases/a_basics/container_testcases.py
+++ b/tests/testcases/a_basics/container_testcases.py
@@ -86,7 +86,7 @@ class TestContainer(BaseTest):
     @parameterized.expand(['before', 'after'])
     @unittest.skip('https://github.com/threefoldtech/0-templates/issues/201')
     def test004_add_zerotier_network_before_and_after_deploying_container(self, state):
-        """ ZRT-ZOS-016
+        """ ZRT-ZOS-004
         *Test case for adding zerotier network before and after deploying the container*
         **Test Scenario:**
 
@@ -119,7 +119,7 @@ class TestContainer(BaseTest):
         self.assertTrue(container_ip, "Failed to retreive zt ip: Cannot get private ip address for zerotier member")
 
     def test005_add_mount_container(self):
-        """ ZRT-ZOS-017
+        """ ZRT-ZOS-005
         *Test case for adding mount directory to container*
         **Test Scenario:**
 
@@ -155,7 +155,7 @@ class TestContainer(BaseTest):
 
     @parameterized.expand(["True", "False"])    
     def test006_add_port_forward_and_host_network_parameters_to_container(self, host_network):
-        """ ZRT-ZOS-018
+        """ ZRT-ZOS-006
         *Test case for adding port forward and host network parameters to container*
         **Test Scenario:**
         #. Create a container (C1) with port forward (P1) and host network True or False.
@@ -203,7 +203,7 @@ class TestContainer(BaseTest):
             self.assertEqual(content, data)
     
     def test007_add_initprocess_to_container(self):
-        """ ZRT-ZOS-019
+        """ ZRT-ZOS-007
         *Test case for adding init process to container*
         **Test Scenario:**
         #. Create a container (C1) with init process.
@@ -230,7 +230,7 @@ class TestContainer(BaseTest):
         self.assertEqual(job['cmd']['arguments']['args'][0], '1000s')
     
     def test008_create_containers_with_same_port_forward(self):
-        """ ZRT-ZOS-020
+        """ ZRT-ZOS-008
         *Test case for creating container with same port forward*
         **Test Scenario:**
         #. Create a container (C1) with port forward (P1).

--- a/tests/testcases/a_basics/dm_vm_testcases.py
+++ b/tests/testcases/a_basics/dm_vm_testcases.py
@@ -42,29 +42,28 @@ class DmVm_Testcases(BaseTest):
             result = self.ssh_vm_execute_command(vm_ip=vm_zt_ip, cmd='pwd')
             self.assertEqual(result, '/root')
         
-    @parameterized.expand([('zero-os', 'ext4'), ('zero-os', 'ext3'), ('zero-os', 'ext2'), ('zero-os', 'btrfs'),
-                           ('ubuntu', 'ext4'), ('ubuntu', 'ext3'), ('ubuntu', 'ext2'), ('ubuntu', 'btrfs')])
-    def test002_attach_disk_to_vm(self, os_type, filesystem):
+    @parameterized.expand(['zero-os', 'ubuntu'])
+    def test002_attach_disk_to_vm(self, os_type):
         """ ZRT-ZOS-033
         * Test case for adding vdisk to the vm.*
 
         **Test Scenario:**
         
-        #. Create vm [VM] with disk [D], should succeed.
-        #. Check that disk [D1] added successfully to vm.
+        #. Create vm [VM] with disk [D1], should succeed.
+        #. Check that disk [D1] has been added successfully to vm.
         """
         if os_type == 'zero-os':
             # config is not working on current zos flist, and sal code is using config to make filesystem and mointpoint
             self.skipTest("https://github.com/threefoldtech/jumpscale_prefab/issues/32")
 
-        self.log('Create vm [VM] with disk [D], should succeed.')
+        self.log('Create vm [VM] with disk [D1], should succeed.')
         vm = self.controller.dm_vm
         ssh_config = [{'path': '/root/.ssh/authorized_keys', 'content': self.ssh_key, 'name': 'sshkey'}]
         disk = [{'label': 'label',
                  'diskType': self.disk_type,
                  'size': random.randint(1, int(self.disk_size/10)),
                  'mountPoint':'/mnt/{}'.format(self.random_string()),
-                 'filesystem': filesystem,
+                 'filesystem': 'ext4',
                  }]
         vm.install(wait=True, configs=ssh_config, ports=[], image=os_type, disks=disk)
         self.vms.append(vm)
@@ -72,21 +71,21 @@ class DmVm_Testcases(BaseTest):
         self.log('Get zerotier ip from vm info.')
         vm_zt_ip = self.get_dm_vm_zt_ip(vm)
 
-        self.log('Check that disk [D1] added successfully to vm.')
+        self.log('Check that disk [D1] has been added successfully to vm.')
         if os_type == 'zero-os':
             node = j.clients.zos.get(self.random_string(), data={'host': vm_zt_ip})
             disks = node.client.disks.list()
             self.assertEqual(len(disks), 1)
             disk_size = int(disks[0]['size']/(1024**3))
             self.assertEqual(disk_size, disk[0]['size'])
-            self.assertEqual(disk[0]['fstype'], filesystem)
+            self.assertEqual(disk[0]['fstype'], 'ext4')
             self.assertEqual(disk[0]['mountpoint'], disk[0]['mountPoint'])            
         else:
             self.assertTrue(vm.info().result['disks']) 
             cmd = 'df -Th | grep {} '.format(disk[0]['mountPoint'])
             result = self.ssh_vm_execute_command(vm_ip=vm_zt_ip, cmd=cmd)
             disk_filesystem = result.split()[1]
-            self.assertEqual(disk_filesystem, filesystem)
+            self.assertEqual(disk_filesystem, 'ext4')
     
     @parameterized.expand(['zero-os', 'ubuntu'])
     def test003_add_remove_port_forward_to_vm(self, os_type):
@@ -96,9 +95,9 @@ class DmVm_Testcases(BaseTest):
 
         #. Create vm[VM1], should succeed.
         #. Check vm info, ports should be empty.
-        #. Add port forward [p1] to [VM1], should succeed.
-        #. Check vm info again, ports should be found.
-        #. Remove port forward [p1] from [VM1], should succeed.
+        #. Add port forward [P1] to [VM1], should succeed.
+        #. Check vm info again, P1 should be found.
+        #. Remove port forward [P1] from [VM1], should succeed.
         #. Check vm info again, ports should be empty.
         """
         self.log('Create vm[VM1], should succeed.')
@@ -112,19 +111,19 @@ class DmVm_Testcases(BaseTest):
         vm_info = [v for v in vms if vm.service.data['guid'] in v['name']]
         self.assertFalse(vm_info[0]['params']['port'])
 
-        self.log('Add port forward [p1] to [VM1], should succeed.')
+        self.log('Add port forward [P1] to [VM1], should succeed.')
         port_name = self.random_string()   
         host_port = random.randint(3000, 4000)
         guest_port = random.randint(5000, 6000)
         vm.add_portforward(name=port_name, source=host_port, target=guest_port)
 
-        self.log("Check vm info again, ports should be found.")
+        self.log("Check vm info again, P1 should be found.")
         vms = self.controller.node.client.kvm.list()
         vm_info = [v for v in vms if vm.service.data['guid'] in v['name']]
         port = {'{}'.format(host_port): guest_port}
         self.assertEqual(vm_info[0]['params']['port'], port)
 
-        self.log('Remove port forward [p1] from [VM1], should succeed.')
+        self.log('Remove port forward [P1] from [VM1], should succeed.')
         vm.remove_portforward(port_name)
 
         self.log("Check vm info again, ports should be empty.")

--- a/tests/testcases/a_basics/gw_testcases.py
+++ b/tests/testcases/a_basics/gw_testcases.py
@@ -22,7 +22,7 @@ class GWTests(BaseTest):
         super().tearDown()
         
     def test001_deploy_getway_with_without_public_network(self):
-        """ ZRT-ZOS-021
+        """ ZRT-ZOS-043
         *Test case for deploying gateway with/without default public network .
         Test Scenario:
 
@@ -43,7 +43,7 @@ class GWTests(BaseTest):
         self.gws.append(gateway)
     
     def test002_add_network_name_exist(self):
-        """ZRT-ZOS-022
+        """ZRT-ZOS-044
         *Test case for adding network to gateway with same name.
         Test Scenario:
 
@@ -70,7 +70,7 @@ class GWTests(BaseTest):
 
     @unittest.skip('https://github.com/threefoldtech/0-templates/issues/218')
     def test003_add_zerotier_network(self):
-        """ZRT-ZOS-023
+        """ZRT-ZOS-045
         *Test case for adding zerotier network to gateway .
         Test Scenario:
 
@@ -101,7 +101,7 @@ class GWTests(BaseTest):
         zt_client.delete()
     
     def test004_remove_network(self):
-        """ZRT-ZOS-024
+        """ZRT-ZOS-046
         *Test case for removing network from gateway .
         Test Scenario:
 
@@ -133,7 +133,7 @@ class GWTests(BaseTest):
         self.assertNotEqual(info['networks'][0]['type'], 'zerotier')
 
     def test005_deploy_getways_with_same_default_public_network(self):
-        """ZRT-ZOS-025
+        """ZRT-ZOS-047
         *Test case for deploying more than one gateway with default public network .
         Test Scenario:
 
@@ -154,7 +154,7 @@ class GWTests(BaseTest):
 
     @unittest.skip("https://github.com/threefoldtech/0-templates/issues/226")
     def test006_create_gateway_with_port_forward(self):
-        """ZRT-ZOS-026
+        """ZRT-ZOS-048
         *Test case for creating gateway with port forward
         Test Scenario:
 
@@ -203,7 +203,7 @@ class GWTests(BaseTest):
 
     @unittest.skip('https://github.com/threefoldtech/0-templates/issues/218')
     def test007_stop_and_start_gateway(self):
-        """ZRT-ZOS-027
+        """ZRT-ZOS-049
         *Test case for stopping and starting gateway .
         Test Scenario:
 

--- a/tests/testcases/a_basics/node_testcases.py
+++ b/tests/testcases/a_basics/node_testcases.py
@@ -9,7 +9,7 @@ class NodeTestcases(BaseTest):
         self.node_tem = self.controller.node_manager
 
     def test001_get_node_info(self):
-        """ ZRT-ZOS-000
+        """ ZRT-ZOS-039
         *Test case for getting node info *
 
         **Test Scenario:**
@@ -28,7 +28,7 @@ class NodeTestcases(BaseTest):
             self.assertAlmostEqual(node_info[key], ser_info.result[key], delta=10)
 
     def test002_get_node_stats(self):
-        """ ZRT-ZOS-000
+        """ ZRT-ZOS-040
         *Test case for getting node statistics *
 
         **Test Scenario:**
@@ -46,7 +46,7 @@ class NodeTestcases(BaseTest):
         self.assertEqual(len(ser_stats.result), len(node_stats))
 
     def test003_get_node_processes(self):
-        """ ZRT-ZOS-000
+        """ ZRT-ZOS-041
         *Test case for getting node processes *
 
         **Test Scenario:**
@@ -64,7 +64,7 @@ class NodeTestcases(BaseTest):
         self.assertEqual(len(ser_processes.result), len(node_processes))
 
     def test004_get_node_os_version(self):
-        """ ZRT-ZOS-000
+        """ ZRT-ZOS-042
         *Test case for getting node os version *
 
         **Test Scenario:**

--- a/tests/testcases/a_basics/ns_testcases.py
+++ b/tests/testcases/a_basics/ns_testcases.py
@@ -31,7 +31,7 @@ class NSTestCases(BaseTest):
 
     @parameterized.expand(para_list)
     def test001_create_namespace(self, mode, public, disk_type):
-        """ ZRT-ZOS-028
+        """ ZRT-ZOS-025
         *Test case for creating namespace *
 
         **Test Scenario:**
@@ -62,7 +62,7 @@ class NSTestCases(BaseTest):
         self.assertEqual(info['public'], public)
 
     def test002_uninstall_namespace_with_zdb(self):
-        """ ZRT-ZOS-029
+        """ ZRT-ZOS-026
         *Test case for uninstalling namespace *
 
         **Test Scenario:**

--- a/tests/testcases/a_basics/vm_testcases.py
+++ b/tests/testcases/a_basics/vm_testcases.py
@@ -28,7 +28,7 @@ class TestVm(BaseTest):
         super().tearDown()
 
     def test001_create_vm(self):
-        """ ZRT-ZOS-003
+        """ ZRT-ZOS-009
         *Test case for creating a vm.*
 
         **Test Scenario:**
@@ -62,7 +62,7 @@ class TestVm(BaseTest):
         self.assertFalse(vm)
 
     def test002_create_vm_with_non_valid_params(self):
-        """ ZRT-ZOS-004
+        """ ZRT-ZOS-010
         *Test case for creating vm with non-valid parameters*
 
         **Test Scenario:**
@@ -78,7 +78,7 @@ class TestVm(BaseTest):
         self.assertIn( "invalid input. Vm requires flist or ipxeUrl to be specifed.", e.exception.args[0])
 
     def test003_create_vm_with_zt_network(self):
-        """ZRT-ZOS-013
+        """ZRT-ZOS-011
         * Test case for creating a vm with zerotier netwotk.
         Test Scenario:
 
@@ -109,7 +109,7 @@ class TestVm(BaseTest):
         zt_client.delete()
         
     def test004_add_remove_port_forward_to_vm(self):
-        """ZRT-ZOS-014
+        """ZRT-ZOS-012
         * Test case for adding and removing port forward to vm.
         Test Scenario:
 
@@ -156,7 +156,7 @@ class TestVm(BaseTest):
 
     @parameterized.expand(['ext4', 'ext3', 'ext2', 'btrfs'])
     def test005_add_vdisk_from_vm(self, filesystem):
-        """ ZRT-ZOS-015
+        """ ZRT-ZOS-013
         * Test case for adding vdisk to the vm.
         **Test Scenario:**
         
@@ -214,7 +214,7 @@ class VM_actions(BaseTest):
         self.vm.service.delete()
 
     def test001_pause_and_resume_vm(self):
-        """ ZRT-ZOS-005
+        """ ZRT-ZOS-014
         *Test case for testing pause and resume vm*
 
         **Test Scenario:**
@@ -244,7 +244,7 @@ class VM_actions(BaseTest):
         self.assertEqual(result, '/root')
 
     def test002_shutdown_and_start_vm(self):
-        """ ZRT-ZOS-006
+        """ ZRT-ZOS-015
         *Test case for testing shutdown and start vm*
 
         **Test Scenario:**
@@ -276,7 +276,7 @@ class VM_actions(BaseTest):
         self.assertEqual(result, '/root')
 
     def test003_enable_and_disable_vm_vnc(self):
-        """ ZRT-ZOS-007
+        """ ZRT-ZOS-016
         *Test case for testing enable and disable vnc port*
 
         **Test Scenario:**
@@ -306,7 +306,7 @@ class VM_actions(BaseTest):
     @parameterized.expand(["reset", "reboot"])    
     @unittest.skip("https://github.com/threefoldtech/0-core/issues/35")
     def test004_reset_and_reboot_vm(self, action_type):
-        """ ZRT-ZOS-008
+        """ ZRT-ZOS-017
         *Test case for testing reset and reboot vm*
 
         **Test Scenario:**

--- a/tests/testcases/a_basics/zdb_testcases.py
+++ b/tests/testcases/a_basics/zdb_testcases.py
@@ -18,7 +18,7 @@ class ZDBTestCases(BaseTest):
     @parameterized.expand(['user', 'seq', 'direct'])
     @unittest.skip('https://github.com/threefoldtech/jumpscale_lib/issues/208')
     def test001_create_zdb(self, mode):
-        """ ZRT-ZOS-009
+        """ ZRT-ZOS-018
         *Test case for creating zerodb *
 
         **Test Scenario:**
@@ -44,7 +44,7 @@ class ZDBTestCases(BaseTest):
         self.zdbs.append(zdb)
         
     def test002_create_list_namespaces(self):
-        """ ZRT-ZOS-010
+        """ ZRT-ZOS-019
         *Test case for creating and listing namespaces*
 
         **Test Scenario:**
@@ -77,7 +77,7 @@ class ZDBTestCases(BaseTest):
 
     @parameterized.expand(['password', 'public', 'size'])
     def test003_set_namespace_properities(self, prop):
-        """ ZRT-ZOS-011
+        """ ZRT-ZOS-020
         *Test case for setting namespace properities*
 
         **Test Scenario:**
@@ -120,7 +120,7 @@ class ZDBTestCases(BaseTest):
         self.zdbs.append(zdb)
 
     def test004_start_stop_zerodb(self):
-        """ ZRT-ZOS-012
+        """ ZRT-ZOS-021
         *Test case for starting and stopping zerodb service*
 
         **Test Scenario:**


### PR DESCRIPTION
Edit test IDs.
Unskip bridge testcases.
Add testcase for:
- attaching vdisk to dm_vm.
- adding/removing port forward to/from dm_vm.

Result of bridge tests:
```
ZRT-ZOS-026 [with mode='none'] ... skipped
ZRT-ZOS-026 [with mode='static'] ... [Tue11 09:45] - base_test.py      :92  :j.testsuite.log      - INFO     - Create bridge (B1) with different modes, should succeed
[Tue11 09:45] - base_test.py      :92  :j.testsuite.log      - INFO     - Check that the params has been reflected correctly
passed
ZRT-ZOS-026 [with mode='dnsmasq'] ... [Tue11 09:45] - base_test.py      :92  :j.testsuite.log      - INFO     - Create bridge (B1) with different modes, should succeed
[Tue11 09:45] - base_test.py      :92  :j.testsuite.log      - INFO     - Check that the params has been reflected correctly
passed
ZRT-ZOS-027 ... skipped
ZRT-ZOS-028 ... skipped
ZRT-ZOS-029 ... skipped
ZRT-ZOS-030 ... skipped
ZRT-ZOS-031 [with nat='True'] ... [Tue11 09:45] - base_test.py      :92  :j.testsuite.log      - INFO     - Create bridge (B1) with nat = False/True, should succeed
[Tue11 09:45] - base_test.py      :92  :j.testsuite.log      - INFO     - Create container (C1) and attach bridge (B1) to it, should succeed.
[Tue11 09:45] - container.py      :50  :j.controller.log     - INFO     - Install container_4e437ca3242355899f17ee container
[Tue11 09:47] - base_test.py      :92  :j.testsuite.log      - INFO     - Add ip to eth0 and set it up
[Tue11 09:47] - base_test.py      :92  :j.testsuite.log      - INFO     - set network interface eth0 as default route, should succeed
[Tue11 09:47] - base_test.py      :92  :j.testsuite.log      - INFO     - Try to ping 8.8.8.8 when NAT is enabled, should succeed
[Tue11 09:48] - container.py      :55  :j.controller.log     - INFO     - Uninstall container_4e437ca3242355899f17ee conatiner
passed
ZRT-ZOS-031 [with nat='False'] ... [Tue11 09:48] - base_test.py      :92  :j.testsuite.log      - INFO     - Create bridge (B1) with nat = False/True, should succeed
[Tue11 09:48] - base_test.py      :92  :j.testsuite.log      - INFO     - Create container (C1) and attach bridge (B1) to it, should succeed.
[Tue11 09:48] - container.py      :50  :j.controller.log     - INFO     - Install container_1e4258a23cadb2d78dd37f container
[Tue11 09:49] - base_test.py      :92  :j.testsuite.log      - INFO     - Add ip to eth0 and set it up
[Tue11 09:50] - base_test.py      :92  :j.testsuite.log      - INFO     - set network interface eth0 as default route, should succeed
[Tue11 09:50] - base_test.py      :92  :j.testsuite.log      - INFO     - Try to ping 8.8.8.8 when NAT is disabled, should fail
[Tue11 09:50] - container.py      :55  :j.controller.log     - INFO     - Uninstall container_1e4258a23cadb2d78dd37f conatiner
passed
======================================================================
1) SKIP: ZRT-ZOS-026 [with mode='none']
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/0-templates/issues/258
======================================================================
2) SKIP: ZRT-ZOS-027
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/0-templates/issues/258
======================================================================
3) SKIP: ZRT-ZOS-028
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/0-templates/issues/258
======================================================================
4) SKIP: ZRT-ZOS-029
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/0-core/issues/87
======================================================================
5) SKIP: ZRT-ZOS-030
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/0-templates/issues/258

-----------------------------------------------------------------------------
9 tests run in 313.296 seconds. 
5 skipped (4 tests passed)

```
