### PR TITLE
continue zdb testcases

### DIFF
--- a/tests/controller/templates_manager/local_temp/zerodb.py
+++ b/tests/controller/templates_manager/local_temp/zerodb.py
@@ -22,18 +22,20 @@ class ZDBManager:
             return self._zdb_service
 
     def install(self, path, wait=True, **kwargs):
-        default_data = {
+        self.default_data = {
             'name' : self._parent.random_string(),
             'sync': True,
             'mode': 'user',
             'admin': self._parent.random_string(),
-            'path': path
+            'path': path,
+            'namespaces': [],
+            'nics': []
         }
         if kwargs:
-            default_data.update(kwargs)
+            self.default_data.update(kwargs)
 
-        self.zdb_service_name = default_data['name']
-        self._zdb_service = self.robot.services.create(self.zdb_template, self.zdb_service_name, default_data)
+        self.zdb_service_name = self.default_data['name']
+        self._zdb_service = self.robot.services.create(self.zdb_template, self.zdb_service_name, self.default_data)
         self._zdb_service.schedule_action('install').wait(die=wait)
 
     def info(self):

--- a/tests/testcases/a_basics/ns_testcases.py
+++ b/tests/testcases/a_basics/ns_testcases.py
@@ -80,11 +80,7 @@ class NSTestCases(BaseTest):
         self.log("Get the zdb that namespace (NS1) has been created on")
         url = self.ns.private_url().result
         d_type, zdb_ser_name = self.get_namespace_disk_type(url)
-        robot_name = self.random_string()
-        j.clients.zrobot.get(robot_name, data={'url': self.config['robot']['remote_server']})
-        robot = j.clients.zrobot.robots[robot_name]
-        robot = self.robot_god_token(self.controller.remote_robot)
-        zdb = robot.services.get(name=zdb_ser_name)
+        zdb = self.controller.remote_robot.services.get(name=zdb_ser_name)
 
         self.log('Check that namesapce (NS1) in namespace list, should be found.')
         ns_found = self.find_namespace_in_list(zdb, self.ns.default_data['nsName'])

--- a/tests/testcases/a_basics/zdb_testcases.py
+++ b/tests/testcases/a_basics/zdb_testcases.py
@@ -181,7 +181,9 @@ class ZDBTestCases(BaseTest):
         namespaces = zdb.namespace_list()
         self.assertEqual(len(namespaces.result), 1)
         self.assertEqual(namespaces.result[0]['name'], ns_name)
-        
+        response = self.node.client.bash("ls {}/data/{}".format(self.mount_paths, ns_name)).get()
+        self.assertEqual(response.state, 'SUCCESS')
+
         self.log("Delete namespace (NS), should succeed.")
         delete = zdb.namespace_delete(name=ns_name)
         time.sleep(2)
@@ -190,6 +192,9 @@ class ZDBTestCases(BaseTest):
         self.log('list the namespaces, should be empty')
         namespaces = zdb.namespace_list()
         self.assertEqual(namespaces.result, [])
+        response = self.node.client.bash("ls {}/data/{}".format(self.mount_paths, ns_name)).get()
+        self.assertEqual(response.state, 'ERROR')
+        self.assertIn("No such file or directory", response.stderr.strip())
     
     def test006_zdb_with_zerotier_nics(self):
         """ ZRT-ZOS-023


### PR DESCRIPTION
- edit namespace uninstall testcase
- add testcase for 
- removing namespace
- add zerotier network to zdb

#### Result:
- namespace
```
ZRT-ZOS-029 ... [Tue11 12:43] - base_test.py      :91  :j.testsuite.log      - INFO     - Create namespace (NS1) with basic params, should succeed.
[Tue11 12:44] - base_test.py      :91  :j.testsuite.log      - INFO     - Get the zdb that namespace (NS1) has been created on
[Tue11 12:49] - base_test.py      :91  :j.testsuite.log      - INFO     - Check that namesapce (NS1) in namespace list, should be found.
[Tue11 12:49] - base_test.py      :91  :j.testsuite.log      - INFO     - Uninstall namespace (NS1).
[Tue11 12:49] - base_test.py      :91  :j.testsuite.log      - INFO     - Check that namespace (NS1) in namespace list, should not be found.
passed

-----------------------------------------------------------------------------
1 test run in 700.962 seconds (1 test passed)

```
- zdb
```
ZRT-ZOS-009 [with *args=('user',)] ... skipped
ZRT-ZOS-009 [with *args=('seq',)] ... skipped
ZRT-ZOS-009 [with *args=('direct',)] ... skipped
ZRT-ZOS-010 ... [Tue11 11:36] - base_test.py      :91  :j.testsuite.log      - INFO     - Create zerodb (zdb) with basic params, should succeed
[Tue11 11:36] - base_test.py      :91  :j.testsuite.log      - INFO     - list the namespaces, should be empty
[Tue11 11:36] - base_test.py      :91  :j.testsuite.log      - INFO     - Create namespace (NS), should succeed
[Tue11 11:36] - base_test.py      :91  :j.testsuite.log      - INFO     - List namespaces, NS should be found
passed
ZRT-ZOS-011 [with prop='password'] ... [Tue11 11:36] - base_test.py      :91  :j.testsuite.log      - INFO     - Create zerodb (zdb) with basic params, should succeed
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Create namespace (NS), should succeed
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - set the namespace (NS) settings
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Check that NS setting has been changed
passed
ZRT-ZOS-011 [with prop='public'] ... [Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Create zerodb (zdb) with basic params, should succeed
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Create namespace (NS), should succeed
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - set the namespace (NS) settings
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Check that NS setting has been changed
passed
ZRT-ZOS-011 [with prop='size'] ... [Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Create zerodb (zdb) with basic params, should succeed
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Create namespace (NS), should succeed
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - set the namespace (NS) settings
[Tue11 11:37] - base_test.py      :91  :j.testsuite.log      - INFO     - Check that NS setting has been changed
passed
ZRT-ZOS-012 ... [Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Create namespace (NS), should succeed
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Stop zerodb service, should succeed
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Make sure zerodb container has been removed
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Start zerodb service, should succeed.
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Check that Namespace (NS) is still there.
passed
ZRT-ZOS-029 ... [Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Create zerodb (zdb) with basic params, should succeed
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - List namespaces, NS should be found
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Delete namespace (NS), should succeed.
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - list the namespaces, should be empty
passed
ZRT-ZOS-029 ... [Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Create zerodb (zdb) with basic params, should succeed
[Tue11 11:38] - base_test.py      :91  :j.testsuite.log      - INFO     - Check that zdb got a zerotier ip.
passed
======================================================================
1) SKIP: ZRT-ZOS-009 [with *args=('user',)]
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/jumpscale_lib/issues/208
======================================================================
2) SKIP: ZRT-ZOS-009 [with *args=('seq',)]
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/jumpscale_lib/issues/208
======================================================================
3) SKIP: ZRT-ZOS-009 [with *args=('direct',)]
----------------------------------------------------------------------
   No Traceback
   SkipTest: https://github.com/threefoldtech/jumpscale_lib/issues/208

-----------------------------------------------------------------------------
10 tests run in 512.524 seconds. 
3 skipped (7 tests passed)
```
