### PR TITLE
node_port_manager test cases

### DIFF
--- a/tests/controller/controller.py
+++ b/tests/controller/controller.py
@@ -1,7 +1,7 @@
 from Jumpscale import j
 from uuid import uuid4
 from testconfig import config
-from tests.controller.templates_manager.local_temp import vm, container, zerodb, vdisk, gateway, namespace, bridge, node
+from tests.controller.templates_manager.local_temp import vm, container, zerodb, vdisk, gateway, namespace, bridge, node , node_port_manager
 from tests.controller.templates_manager.general_temp import zt_client, dm_vm
 
 logger = j.logger.get('controller.log')
@@ -28,6 +28,7 @@ class Controller:
 
         # get instance from all templates_manager
         self.vm_manager = vm.VMManager(parent=self, service_name=None)
+        self.node_port_manager = node_port_manager.NodePortManager(parent=self)
         self.dm_vm = dm_vm.DMVMManager(parent=self, service_name=None)
         self.zdb_manager = zerodb.ZDBManager(parent=self, service_name=None)
         self.vdisk = vdisk.VdiskManager(parent=self, service_name=None)

--- a/tests/controller/templates_manager/local_temp/node_port_manager.py
+++ b/tests/controller/templates_manager/local_temp/node_port_manager.py
@@ -1,0 +1,29 @@
+from Jumpscale import j
+from zerorobot.service_collection import ServiceNotFoundError
+from testconfig import config
+
+
+class NodePortManager:
+    def __init__(self, parent):
+        self.node_template = 'github.com/threefoldtech/0-templates/node_port_manager/0.0.1'
+        self._parent = parent
+        self.logger = self._parent.logger
+        self.robot = self._parent.remote_robot
+        self._node_service = None
+
+
+    @property
+    def service(self):
+        if self._node_service is None:
+            self._node_service = self.robot.services.find(template_name='node_port_manager')[0]
+        return self._node_service
+
+    def reserve(self, guid, n=1):
+
+        return self.service.schedule_action('reserve', {"service_guid": guid, "n": n}).wait(die=True)
+
+    def release(self, guid, ports):
+
+        return self.service.schedule_action('release', {"service_guid": guid, 'ports': ports}).wait(die=True)
+
+

--- a/tests/controller/templates_manager/local_temp/node_port_manager.py
+++ b/tests/controller/templates_manager/local_temp/node_port_manager.py
@@ -13,8 +13,7 @@ class NodePortManager:
 
     @property
     def service(self):
-        if self._node_service is None:
-            self._node_service = self.robot.services.find(template_name='node_port_manager')[0]
+        self._node_service = self.robot.services.find(template_name='node_port_manager')[0]
         return self._node_service
 
     def reserve(self, guid, n=1):

--- a/tests/controller/templates_manager/local_temp/node_port_manager.py
+++ b/tests/controller/templates_manager/local_temp/node_port_manager.py
@@ -11,7 +11,6 @@ class NodePortManager:
         self.robot = self._parent.remote_robot
         self._node_service = None
 
-
     @property
     def service(self):
         if self._node_service is None:
@@ -19,11 +18,7 @@ class NodePortManager:
         return self._node_service
 
     def reserve(self, guid, n=1):
-
         return self.service.schedule_action('reserve', {"service_guid": guid, "n": n}).wait(die=True)
 
     def release(self, guid, ports):
-
         return self.service.schedule_action('release', {"service_guid": guid, 'ports': ports}).wait(die=True)
-
-

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -1,0 +1,68 @@
+from tests.testcases.base_test import BaseTest
+import unittest
+import time
+
+
+
+
+class NodePortManagerTestcases(BaseTest):
+
+
+    def test001_reserve_release_port_using_service_guid(self):
+
+        """
+            *Test case for reserving ports using service guid .
+            Test Scenario:
+
+            #. get a running service GUID and reserve two ports using it , should success.
+            #. release this two ports one by one , should success
+            #. make sure that the port is released by reserve another new port again
+
+        """
+        node_service = self.controller.node_manager
+        guid = node_service.service.guid
+        self.log('reserving two ports for one service')
+        node_port = self.controller.node_port_manager
+        ports = node_port.reserve(guid, 2).result
+        self.assertTrue(ports)
+        port_reserved_1 = ports[0]
+        port_reserved_2 = ports[1]
+        self.log('releasing  the 1st reserved port for one service')
+        node_port.release(guid, [port_reserved_1])
+        time.sleep(10)
+        node_port = self.controller.node_port_manager
+        for port in node_port.service.data["data"]["ports"]:
+            if port['port'] == port_reserved_1:
+                print("failed")
+        self.log('releasing  the 2nd reserved port for one service')
+        node_port.release(guid, [port_reserved_2])
+
+
+
+
+
+        #self.assertEqual(port_reserved_3, port_reserved_1)
+
+
+    def test002_reserve_with_guid1_release_with_guid2(self):
+
+        """
+            *Test case for reserving port using guid and release it with different GUID
+
+            #. get running serviceguid and reserve  port using it
+            #. try to release this port using different service guid , should fail
+            #. release this port using same GUID , should success
+        """
+
+        node_service = self.controller.node_manager
+        guid = node_service.service.guid
+        guid2 = (self.controller.remote_robot.services.find(template_name='node_capacity')[0]).guid
+        node_port = self.controller.node_port_manager
+        port = node_port.reserve(guid).result
+        self.assertTrue(port)
+        self.log('releasing the reserved port with different guid , should fail')
+        with self.assertRaises(Exception):
+            node_port.release(guid2, port)
+        self.log('releasing the reserved port with right guid , should success')
+        node_port.release(guid, port)
+

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -29,7 +29,6 @@ class NodePortManagerTestcases(BaseTest):
                 self.assertEqual(port, port_reserved_1)
                 self.assertEqual(port, port_reserved_2)
 
-        self.log('ports {},{} reserved successfully').format(port_reserved_1, port_reserved_2)
         self.log('release this two ports one by one , should success')
         node_port.release(guid, [port_reserved_1])
         for port in node_port.service.data["data"]["ports"]:

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -11,7 +11,7 @@ class NodePortManagerTestcases(BaseTest):
 
         #. get a running service GUID and reserve two ports using it, should success.
         #. make sure that this two ports is reserved, should success.
-        #. release this two ports one by one, should success.
+        #. release this two ports, should success.
         #. make sure that the port is released by checking that it's not in reserved ports.
         """
         self.log('get a running service GUID and reserve two ports using it, should success')
@@ -29,8 +29,8 @@ class NodePortManagerTestcases(BaseTest):
                 self.assertEqual(port, port_reserved_1)
                 self.assertEqual(port, port_reserved_2)
 
-        self.log('release this two ports one by one, should success')
-        node_port.release(guid, [port_reserved_1])
+        self.log('release this two ports, should success')
+        node_port.release(guid, ports)
 
         self.log("make sure that the port is released by checking that it's not in reserved ports.")
         for port in node_port.service.data["data"]["ports"]:

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -1,62 +1,67 @@
 from tests.testcases.base_test import BaseTest
 import unittest
-import time
 
 
 class NodePortManagerTestcases(BaseTest):
 
     def test001_reserve_release_port_using_service_guid(self):
 
-        """
-            *Test case for reserving ports using service guid .
+        """ZRT-ZOS-050
+            *Test case for reserving and releasing ports using service guid .
             Test Scenario:
 
-            #. get a running service GUID and reserve two ports using it , should success.
+            #. get a running service GUID and reserve two ports using it, should success.
             #. release this two ports one by one , should success
-            #. make sure that the port is released by reserve another new port again
+            #. make sure that the port is released by checking that it's not in reserved ports
 
         """
-        node_service = self.controller.node_manager
-        guid = node_service.service.guid
+        node = self.controller.node_manager
+        guid = node.service.guid
 
-        self.log('reserving two ports for one service')
+        self.log('get a running service GUID and reserve two ports using it , should success')
         node_port = self.controller.node_port_manager
         ports = node_port.reserve(guid, 2).result
         self.assertTrue(ports)
         port_reserved_1 = ports[0]
         port_reserved_2 = ports[1]
+        for port in node_port.service.data["data"]["ports"]:
+            if port['port'] in ports:
+                self.assertEqual(port, port_reserved_1)
+                self.assertEqual(port, port_reserved_2)
 
-        self.log('releasing  the 1st reserved port for one service')
+        self.log('ports {},{} reserved successfully').format(port_reserved_1, port_reserved_2)
+        self.log('release this two ports one by one , should success')
         node_port.release(guid, [port_reserved_1])
-        time.sleep(10)
-        node_port = self.controller.node_port_manager
         for port in node_port.service.data["data"]["ports"]:
             if port['port'] == port_reserved_1:
-                print("failed")
+                self.assertEqual(port, port_reserved_1)
 
         self.log('releasing  the 2nd reserved port for one service')
         node_port.release(guid, [port_reserved_2])
 
     def test002_reserve_with_guid1_release_with_guid2(self):
 
-        """
-            *Test case for reserving port using guid and release it with different GUID
+        """ZRT-ZOS-051
+        *Test case for reserving port using guid and release it with different GUID
+        Test Scenario:
 
-            #. get running serviceguid and reserve  port using it
-            #. try to release this port using different service guid , should fail
-            #. release this port using same GUID , should success
-        """
+        #. get running service guid and reserve port using it
+        #. try to release this port using different service guid , should fail
+        #. release this port using right GUID , should success
+    """
 
-        node_service = self.controller.node_manager
-        guid = node_service.service.guid
+        node = self.controller.node_manager
+
+        self.log('get running service guid and reserve port using it')
+        guid = node.service.guid
         guid2 = (self.controller.remote_robot.services.find(template_name='node_capacity')[0]).guid
         node_port = self.controller.node_port_manager
         port = node_port.reserve(guid).result
         self.assertTrue(port)
 
-        self.log('releasing the reserved port with different guid , should fail')
+        self.log('try to release this port using different service guid , should fail')
         with self.assertRaises(Exception):
             node_port.release(guid2, port)
 
-        self.log('releasing the reserved port with right guid , should success')
+        self.log('release this port using right GUID , should success')
         node_port.release(guid, port)

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -5,62 +5,61 @@ import unittest
 class NodePortManagerTestcases(BaseTest):
 
     def test001_reserve_release_port_using_service_guid(self):
-
         """ZRT-ZOS-050
-            *Test case for reserving and releasing ports using service guid .
-            Test Scenario:
+        *Test case for reserving and releasing ports using service guid.
+        Test Scenario:
 
-            #. get a running service GUID and reserve two ports using it, should success.
-            #. release this two ports one by one , should success
-            #. make sure that the port is released by checking that it's not in reserved ports
-
+        #. get a running service GUID and reserve two ports using it, should success.
+        #. make sure that this two ports is reserved, should success.
+        #. release this two ports one by one, should success.
+        #. make sure that the port is released by checking that it's not in reserved ports.
         """
+        self.log('get a running service GUID and reserve two ports using it, should success')
         node = self.controller.node_manager
         guid = node.service.guid
-
-        self.log('get a running service GUID and reserve two ports using it , should success')
         node_port = self.controller.node_port_manager
         ports = node_port.reserve(guid, 2).result
         self.assertTrue(ports)
         port_reserved_1 = ports[0]
         port_reserved_2 = ports[1]
+
+        self.log("make sure that this two ports is reserved, should success.")
         for port in node_port.service.data["data"]["ports"]:
             if port['port'] in ports:
                 self.assertEqual(port, port_reserved_1)
                 self.assertEqual(port, port_reserved_2)
 
-        self.log('release this two ports one by one , should success')
+        self.log('release this two ports one by one, should success')
         node_port.release(guid, [port_reserved_1])
+
+        self.log("make sure that the port is released by checking that it's not in reserved ports.")
         for port in node_port.service.data["data"]["ports"]:
             if port['port'] == port_reserved_1:
                 self.assertEqual(port, port_reserved_1)
 
-        self.log('releasing  the 2nd reserved port for one service')
+        self.log('releasing the 2nd reserved port for one service')
         node_port.release(guid, [port_reserved_2])
 
     def test002_reserve_with_guid1_release_with_guid2(self):
-
         """ZRT-ZOS-051
         *Test case for reserving port using guid and release it with different GUID
         Test Scenario:
 
-        #. get running service guid and reserve port using it
-        #. try to release this port using different service guid , should fail
-        #. release this port using right GUID , should success
-    """
-
-        node = self.controller.node_manager
-
+        #. get running service guid and reserve port using it.
+        #. try to release this port using different service guid, should fail.
+        #. release this port using right GUID, should success.
+        """
         self.log('get running service guid and reserve port using it')
+        node = self.controller.node_manager
         guid = node.service.guid
         guid2 = (self.controller.remote_robot.services.find(template_name='node_capacity')[0]).guid
         node_port = self.controller.node_port_manager
         port = node_port.reserve(guid).result
         self.assertTrue(port)
 
-        self.log('try to release this port using different service guid , should fail')
+        self.log('try to release this port using different service guid, should fail')
         with self.assertRaises(Exception):
             node_port.release(guid2, port)
 
-        self.log('release this port using right GUID , should success')
+        self.log('release this port using right GUID, should success')
         node_port.release(guid, port)

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -3,10 +3,7 @@ import unittest
 import time
 
 
-
-
 class NodePortManagerTestcases(BaseTest):
-
 
     def test001_reserve_release_port_using_service_guid(self):
 
@@ -21,12 +18,14 @@ class NodePortManagerTestcases(BaseTest):
         """
         node_service = self.controller.node_manager
         guid = node_service.service.guid
+
         self.log('reserving two ports for one service')
         node_port = self.controller.node_port_manager
         ports = node_port.reserve(guid, 2).result
         self.assertTrue(ports)
         port_reserved_1 = ports[0]
         port_reserved_2 = ports[1]
+
         self.log('releasing  the 1st reserved port for one service')
         node_port.release(guid, [port_reserved_1])
         time.sleep(10)
@@ -34,15 +33,9 @@ class NodePortManagerTestcases(BaseTest):
         for port in node_port.service.data["data"]["ports"]:
             if port['port'] == port_reserved_1:
                 print("failed")
+
         self.log('releasing  the 2nd reserved port for one service')
         node_port.release(guid, [port_reserved_2])
-
-
-
-
-
-        #self.assertEqual(port_reserved_3, port_reserved_1)
-
 
     def test002_reserve_with_guid1_release_with_guid2(self):
 
@@ -60,9 +53,10 @@ class NodePortManagerTestcases(BaseTest):
         node_port = self.controller.node_port_manager
         port = node_port.reserve(guid).result
         self.assertTrue(port)
+
         self.log('releasing the reserved port with different guid , should fail')
         with self.assertRaises(Exception):
             node_port.release(guid2, port)
+
         self.log('releasing the reserved port with right guid , should success')
         node_port.release(guid, port)
-

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -20,14 +20,14 @@ class NodePortManagerTestcases(BaseTest):
         node_port = self.controller.node_port_manager
         ports = node_port.reserve(guid, 2).result
         self.assertTrue(ports)
-        port_reserved_1 = ports[0]
-        port_reserved_2 = ports[1]
+        port_reserved_1 = {'serviceGuid': guid, 'port': ports[0]}
+        port_reserved_2 = {'serviceGuid': guid, 'port': ports[1]}
 
         self.log("make sure that this two ports is reserved, should success.")
         ports_data = node_port.service.data["data"]["ports"]
         self.assertIn(port_reserved_1, ports_data)
         self.assertIn(port_reserved_2, ports_data)
-        
+
         self.log('release this two ports, should success')
         node_port.release(guid, ports)
 

--- a/tests/testcases/a_basics/node_port_manager_testcases.py
+++ b/tests/testcases/a_basics/node_port_manager_testcases.py
@@ -24,21 +24,17 @@ class NodePortManagerTestcases(BaseTest):
         port_reserved_2 = ports[1]
 
         self.log("make sure that this two ports is reserved, should success.")
-        for port in node_port.service.data["data"]["ports"]:
-            if port['port'] in ports:
-                self.assertEqual(port, port_reserved_1)
-                self.assertEqual(port, port_reserved_2)
-
+        ports_data = node_port.service.data["data"]["ports"]
+        self.assertIn(port_reserved_1, ports_data)
+        self.assertIn(port_reserved_2, ports_data)
+        
         self.log('release this two ports, should success')
         node_port.release(guid, ports)
 
         self.log("make sure that the port is released by checking that it's not in reserved ports.")
-        for port in node_port.service.data["data"]["ports"]:
-            if port['port'] == port_reserved_1:
-                self.assertEqual(port, port_reserved_1)
-
-        self.log('releasing the 2nd reserved port for one service')
-        node_port.release(guid, [port_reserved_2])
+        ports_data = node_port.service.data["data"]["ports"]
+        self.assertNotIn(port_reserved_1, ports_data)
+        self.assertNotIn(port_reserved_2, ports_data)
 
     def test002_reserve_with_guid1_release_with_guid2(self):
         """ZRT-ZOS-051


### PR DESCRIPTION
node_port_manager test cases
```
root@1a2ce0c78812:/opt/code/github/threefoldtech/0-templates/tests# nosetests-3.4 -vs --rednose --logging-level=WARNING testcases/a_basics/node_port_manager_testcases.py --tc-file config.ini
[Wed26 10:20] - SSHKeys.py        :153 :j.clients.sshkey     - INFO     - Will start agent
   52 pts/0    S+     0:00 /bin/bash -c ps ax | grep 'ssh-agent'
   54 pts/0    S+     0:00 grep ssh-agent
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
[Wed26 10:20] - SSHKeys.py        :274 :j.clients.sshkey     - INFO     - load ssh agent
[Wed26 10:20] - SSHKeys.py        :79  :j.clients.sshkey     - INFO     - load ssh key: /root/.ssh/id_rsa
/bin/bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)
Identity added: /root/.ssh/id_rsa (/root/.ssh/id_rsa)
Lifetime set to 86400 seconds
*Test case for reserving ports using service guid . ... [Wed26 10:20] - base_test.py      :92  :j.testsuite.log      - INFO     - reserving two ports for one service
[Wed26 10:20] - base_test.py      :92  :j.testsuite.log      - INFO     - releasing  the 1st reserved port for one service
[Wed26 10:20] - base_test.py      :92  :j.testsuite.log      - INFO     - releasing  the 2nd reserved port for one service
passed
*Test case for reserving port using guid and release it with different GUID ... [Wed26 10:20] - base_test.py      :92  :j.testsuite.log      - INFO     - releasing the reserved port with different guid , should fail
[Wed26 10:20] - base_test.py      :92  :j.testsuite.log      - INFO     - releasing the reserved port with right guid , should success
passed

-----------------------------------------------------------------------------
2 tests run in 27.589 seconds (2 tests passed)

```